### PR TITLE
UAC: Feedback EP

### DIFF
--- a/STM32CubeIDE/USB_HS_TEST/Appli/.cproject
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/.cproject
@@ -77,6 +77,9 @@
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.libraries.1653899320" name="Libraries (-l)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.libraries" valueType="libs">
 									<listOptionValue builtIn="false" value=":USBPDCORE_NOPD_CM7_wc32.a"/>
 								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.otherflags.1514792553" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.otherflags" valueType="stringList">
+									<listOptionValue builtIn="false" value="-Wl,--print-memory-usage"/>
+								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.input.1974926374" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>

--- a/STM32CubeIDE/USB_HS_TEST/Appli/.cproject
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/.cproject
@@ -37,7 +37,7 @@
 							</tool>
 							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.559698425" name="MCU/MPU GCC Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler">
 								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.255456561" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.value.g3" valueType="enumerated"/>
-								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.58592734" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level" useByScannerDiscovery="false"/>
+								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.58592734" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.value.ofast" valueType="enumerated"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.definedsymbols.2121989960" name="Define symbols (-D)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.definedsymbols" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="DEBUG"/>
 									<listOptionValue builtIn="false" value="USE_HAL_DRIVER"/>
@@ -77,7 +77,7 @@
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.libraries.1653899320" name="Libraries (-l)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.libraries" valueType="libs">
 									<listOptionValue builtIn="false" value=":USBPDCORE_NOPD_CM7_wc32.a"/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.otherflags.1514792553" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.otherflags" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.otherflags.1514792553" name="Other flags" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.otherflags" valueType="stringList">
 									<listOptionValue builtIn="false" value="-Wl,--print-memory-usage"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.input.1974926374" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.input">

--- a/STM32CubeIDE/USB_HS_TEST/Appli/Core/Inc/main.h
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/Core/Inc/main.h
@@ -54,7 +54,7 @@ extern "C"
 
 /* Exported constants --------------------------------------------------------*/
 /* USER CODE BEGIN EC */
-#define SAI_BUF_SIZE 4608
+#define SAI_BUF_SIZE 4704  // 4608
     /* USER CODE END EC */
 
     /* Exported macro ------------------------------------------------------------*/

--- a/STM32CubeIDE/USB_HS_TEST/Appli/Core/Src/main.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/Core/Src/main.c
@@ -76,6 +76,7 @@ static inline void clean_ll_cache(void* p, size_t sz)
 volatile uint8_t g_rx_pending = 0;  // bit0: 前半, bit1: 後半 が溜まっている
 volatile uint8_t g_tx_safe    = 1;  // 1: 前半に書いてOK, 2: 後半に書いてOK
 
+volatile uint32_t g_sai_ovrudr_count = 0;
 // === USER CODE END 0 ===
 
 /* USER CODE END PV */
@@ -136,6 +137,12 @@ void HAL_SAI_ErrorCallback(SAI_HandleTypeDef* hsai)
     (void) saiErr;
     (void) dmaErr;
     (void) csr;  // ブレークして値を見る
+
+    if (__HAL_SAI_GET_FLAG(hsai, SAI_FLAG_OVRUDR) != RESET)
+    {
+        g_sai_ovrudr_count++;
+        __HAL_SAI_CLEAR_FLAG(hsai, SAI_FLAG_OVRUDR);
+    }
 }
 /* USER CODE END 0 */
 

--- a/STM32CubeIDE/USB_HS_TEST/Appli/Core/Src/stm32h7rsxx_it.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/Core/Src/stm32h7rsxx_it.c
@@ -113,7 +113,12 @@ void HardFault_Handler(void)
 void MemManage_Handler(void)
 {
     /* USER CODE BEGIN MemoryManagement_IRQn 0 */
-
+    volatile uint32_t cfsr  = SCB->CFSR;  // [7:0] MMFSR
+    volatile uint32_t hfsr  = SCB->HFSR;
+    volatile uint32_t mmfar = SCB->MMFAR;  // アドレス有効時のみ
+    printf("\n[MMF] CFSR=0x%08lX HFSR=0x%08lX MMFAR=0x%08lX\n", cfsr, hfsr, mmfar);
+    /* ビット例: IACCVIOL=1 命令取得違反, DACCVIOL=2 データアクセス違反,
+                 MUNSTKERR=0x08, MSTKERR=0x10, MLSPERR=0x20, MMARVALID=0x80 */
     /* USER CODE END MemoryManagement_IRQn 0 */
     while (1)
     {

--- a/STM32CubeIDE/USB_HS_TEST/Appli/Core/Src/stm32h7rsxx_it.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/Core/Src/stm32h7rsxx_it.c
@@ -95,110 +95,10 @@ void NMI_Handler(void)
 /**
  * @brief This function handles Hard fault interrupt.
  */
-/* 共通：FP文脈が積まれていたら SP を標準フレーム先頭へ進める */
-static inline uint32_t* normalize_sp_for_fp(uint32_t* sp, uint32_t exc_return)
+void HardFault_Handler(void)
 {
-    /* EXC_RETURN bit4=0 の場合は FPコンテキスト (S0..S15, FPSCR, reserved) が先に積まれている */
-    if ((exc_return & (1u << 4)) == 0u)
-    {
-        sp = (uint32_t*) ((uint32_t) sp + (18u * 4u)); /* 18ワード = 72バイト */
-    }
-    return sp;
-}
-
-/* ===== HardFault ===== */
-static void hard_fault_c(uint32_t* sp_raw, uint32_t exc_return)
-{
-    __disable_irq();
-
-    uint32_t* sp = normalize_sp_for_fp(sp_raw, exc_return);
-
-    volatile uint32_t r0  = sp[0];
-    volatile uint32_t r1  = sp[1];
-    volatile uint32_t r2  = sp[2];
-    volatile uint32_t r3  = sp[3];
-    volatile uint32_t r12 = sp[4];
-    volatile uint32_t lr  = sp[5];
-    volatile uint32_t pc  = sp[6];
-    volatile uint32_t psr = sp[7];
-
-    volatile uint32_t cfsr  = SCB->CFSR; /* MMFSR|BFSR|UFSR */
-    volatile uint32_t hfsr  = SCB->HFSR;
-    volatile uint32_t dfsr  = SCB->DFSR;
-    volatile uint32_t afsr  = SCB->AFSR;
-    volatile uint32_t mmfar = SCB->MMFAR;
-    volatile uint32_t bfar  = SCB->BFAR;
-
-    uint8_t mmfsr = (uint8_t) (cfsr & 0xFFu);
-    uint8_t bfsr  = (uint8_t) ((cfsr >> 8) & 0xFFu);
-    uint16_t ufsr = (uint16_t) ((cfsr >> 16) & 0xFFFFu);
-
-    const char* stk_name = (exc_return & 0x4u) ? "PSP" : "MSP";
-
-    printf("\n=== HardFault ===\n");
-    printf("EXC_RETURN=0x%08lX (%s)\n", (unsigned long) exc_return, stk_name);
-    printf("SP(raw)=%p  SP(norm)=%p\n", (void*) sp_raw, (void*) sp);
-    printf("Stacked { R0=%08lX R1=%08lX R2=%08lX R3=%08lX R12=%08lX LR=%08lX PC=%08lX xPSR=%08lX }\n", (unsigned long) r0, (unsigned long) r1, (unsigned long) r2, (unsigned long) r3, (unsigned long) r12, (unsigned long) lr, (unsigned long) pc, (unsigned long) psr);
-
-    printf("CFSR=0x%08lX (MMFSR=%02X BFSR=%02X UFSR=%04X)\n", (unsigned long) cfsr, mmfsr, bfsr, ufsr);
-    printf("HFSR=0x%08lX  DFSR=0x%08lX  AFSR=0x%08lX\n", (unsigned long) hfsr, (unsigned long) dfsr, (unsigned long) afsr);
-
-    /* 有効ならアドレスも出す */
-    if (mmfsr & (1u << 7))
-        printf("MMFAR=0x%08lX (valid)\n", (unsigned long) mmfar);
-    else
-        printf("MMFAR=invalid\n");
-    if (bfsr & (1u << 7))
-        printf("BFAR =0x%08lX (valid)\n", (unsigned long) bfar);
-    else
-        printf("BFAR =invalid\n");
-
-    /* HardFaultの内訳（よく見るビット） */
-    if (hfsr & (1u << 30))
-    {
-        printf(" -> HFSR.FORCED set (下位の CFSR に根本原因あり)\n");
-    }
-    if (hfsr & (1u << 1))
-    {
-        printf(" -> HFSR.VECTTBL set (ベクタ取得中のBusFault)\n");
-    }
-
-    /* 代表的な UFSR の表示（UsageFaultがHardへエスカレートした場合の手掛かり） */
-    if (ufsr & (1u << 9))
-        printf(" -> UFSR.DIVBYZERO\n");
-    if (ufsr & (1u << 8))
-        printf(" -> UFSR.UNALIGNED\n");
-    if (ufsr & (1u << 3))
-        printf(" -> UFSR.NOCP\n");
-    if (ufsr & (1u << 2))
-        printf(" -> UFSR.INVPC\n");
-    if (ufsr & (1u << 1))
-        printf(" -> UFSR.INVSTATE\n");
-    if (ufsr & (1u << 0))
-        printf(" -> UFSR.UNDEFINSTR\n");
-
-    __BKPT(0); /* デバッガ接続時はここで止める（量産時はコメントアウト） */
-    while (1)
-    {} /* 運用によっては NVIC_SystemReset(); に置き換え */
-}
-
-void __attribute__((naked)) HardFault_Handler(void)
-{
-    __asm volatile(
-        "tst lr, #4        \n" /* EXC_RETURN bit2: 0=MSP, 1=PSP */
-        "ite eq            \n"
-        "mrseq r0, msp     \n" /* r0 = SP at fault entry */
-        "mrsne r0, psp     \n"
-        "mov   r1, lr      \n" /* r1 = EXC_RETURN */
-        "b     hard_fault_c\n");
-#if 0
     /* USER CODE BEGIN HardFault_IRQn 0 */
-    volatile uint32_t cfsr  = SCB->CFSR;  // [7:0] MMFSR
-    volatile uint32_t hfsr  = SCB->HFSR;
-    volatile uint32_t bfar  = SCB->BFAR;
-    volatile uint32_t mmfar = SCB->MMFAR;  // アドレス有効時のみ
-    printf("\n[MMF] CFSR=0x%08lX HFSR=0x%08lX BFAR=0x%08lX MMFAR=0x%08lX\n", cfsr, hfsr, bfar, mmfar);
-#endif
+
     /* USER CODE END HardFault_IRQn 0 */
     while (1)
     {
@@ -213,12 +113,7 @@ void __attribute__((naked)) HardFault_Handler(void)
 void MemManage_Handler(void)
 {
     /* USER CODE BEGIN MemoryManagement_IRQn 0 */
-    volatile uint32_t cfsr  = SCB->CFSR;  // [7:0] MMFSR
-    volatile uint32_t hfsr  = SCB->HFSR;
-    volatile uint32_t mmfar = SCB->MMFAR;  // アドレス有効時のみ
-    printf("\n[MMF] CFSR=0x%08lX HFSR=0x%08lX MMFAR=0x%08lX\n", cfsr, hfsr, mmfar);
-    /* ビット例: IACCVIOL=1 命令取得違反, DACCVIOL=2 データアクセス違反,
-                 MUNSTKERR=0x08, MSTKERR=0x10, MLSPERR=0x20, MMARVALID=0x80 */
+
     /* USER CODE END MemoryManagement_IRQn 0 */
     while (1)
     {
@@ -245,84 +140,10 @@ void BusFault_Handler(void)
 /**
  * @brief This function handles Undefined instruction or illegal state.
  */
-/* usage fault のスタックフレームを C 側で可視化するラッパ */
-static void usage_fault_c(uint32_t* sp, uint32_t exc_return);
-
-static void usage_fault_c(uint32_t* sp, uint32_t exc_return)
-{
-    __disable_irq(); /* 追突防止 */
-
-    /* スタックされたレジスタ（ARMv7-M の自動プッシュ順） */
-    volatile uint32_t r0  = sp[0];
-    volatile uint32_t r1  = sp[1];
-    volatile uint32_t r2  = sp[2];
-    volatile uint32_t r3  = sp[3];
-    volatile uint32_t r12 = sp[4];
-    volatile uint32_t lr  = sp[5]; /* return address in normal code */
-    volatile uint32_t pc  = sp[6]; /* 例外発生時に実行していたPC */
-    volatile uint32_t psr = sp[7];
-
-    /* フォルト関連レジスタ */
-    volatile uint32_t cfsr  = SCB->CFSR; /* [7:0]MMFSR, [15:8]BFSR, [31:16]UFSR */
-    volatile uint32_t hfsr  = SCB->HFSR;
-    volatile uint32_t dfsr  = SCB->DFSR;
-    volatile uint32_t mmfar = SCB->MMFAR; /* MMFSR.MMARVALID=1 のとき有効 */
-    volatile uint32_t bfar  = SCB->BFAR;  /* BFSR.BFARVALID=1 のとき有効 */
-    volatile uint32_t afsr  = SCB->AFSR;
-
-    /* サブフィールド（読みやすさ用） */
-    uint8_t mmfsr = (uint8_t) (cfsr & 0xFF);
-    uint8_t bfsr  = (uint8_t) ((cfsr >> 8) & 0xFF);
-    uint16_t ufsr = (uint16_t) ((cfsr >> 16) & 0xFFFF);
-
-    /* ざっくり解釈フラグ（必要に応じて追加してください） */
-    uint8_t mmfar_valid = (mmfsr & (1u << 7)) ? 1u : 0u; /* MMARVALID */
-    uint8_t bfar_valid  = (bfsr & (1u << 7)) ? 1u : 0u;  /* BFARVALID */
-
-    /* どのスタックを使っていたか（EXC_RETURN bit2） */
-    const char* stk_name = (exc_return & 0x4) ? "PSP" : "MSP";
-
-    /* ==== ログ出力 ==== */
-    printf("\n=== UsageFault ===\n");
-    printf("EXC_RETURN=0x%08lX (%s)\n", exc_return, stk_name);
-    printf("SP=%p  stacked { R0=%08lX R1=%08lX R2=%08lX R3=%08lX R12=%08lX LR=%08lX PC=%08lX xPSR=%08lX }\n", (void*) sp, r0, r1, r2, r3, r12, lr, pc, psr);
-
-    printf("CFSR=0x%08lX  (MMFSR=%02X BFSR=%02X UFSR=%04X)\n", cfsr, mmfsr, bfsr, ufsr);
-    printf("HFSR=0x%08lX  DFSR=0x%08lX  AFSR=0x%08lX\n", hfsr, dfsr, afsr);
-    printf("MMFAR=%s0x%08lX  BFAR=%s0x%08lX\n", mmfar_valid ? "" : "(invalid) ", mmfar, bfar_valid ? "" : "(invalid) ", bfar);
-
-    /* 代表的なUFSRビットの簡易表示（必要なら詳細に） */
-    if (ufsr & (1u << 9))
-        printf(" -> DIVBYZERO set\n");
-    if (ufsr & (1u << 8))
-        printf(" -> UNALIGNED set\n");
-    if (ufsr & (1u << 3))
-        printf(" -> NOCP (Coprocessor access) set\n");
-    if (ufsr & (1u << 2))
-        printf(" -> INVPC set\n");
-    if (ufsr & (1u << 1))
-        printf(" -> INVSTATE set\n");
-    if (ufsr & (1u << 0))
-        printf(" -> UNDEFINSTR set\n");
-
-    /* ここでブレークして map と突き合わせるのが定番 */
-    __BKPT(0);
-
-    /* 連続実行を止める。運用に応じて NVIC_SystemReset() 等に置換可 */
-    while (1)
-    { /* hang */
-    }
-}
-void __attribute__((naked)) UsageFault_Handler(void)
+void UsageFault_Handler(void)
 {
     /* USER CODE BEGIN UsageFault_IRQn 0 */
-    __asm volatile(
-        "tst lr, #4        \n" /* EXC_RETURN bit2: 0=MSP, 1=PSP */
-        "ite eq            \n"
-        "mrseq r0, msp     \n"
-        "mrsne r0, psp     \n"
-        "mov   r1, lr      \n" /* r1 = EXC_RETURN */
-        "b     usage_fault_c\n");
+
     /* USER CODE END UsageFault_IRQn 0 */
     while (1)
     {

--- a/STM32CubeIDE/USB_HS_TEST/Appli/Core/Src/stm32h7rsxx_it.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/Core/Src/stm32h7rsxx_it.c
@@ -98,7 +98,11 @@ void NMI_Handler(void)
 void HardFault_Handler(void)
 {
     /* USER CODE BEGIN HardFault_IRQn 0 */
-
+    volatile uint32_t cfsr  = SCB->CFSR;  // [7:0] MMFSR
+    volatile uint32_t hfsr  = SCB->HFSR;
+    volatile uint32_t bfar  = SCB->BFAR;
+    volatile uint32_t mmfar = SCB->MMFAR;  // アドレス有効時のみ
+    printf("\n[MMF] CFSR=0x%08lX HFSR=0x%08lX BFAR=0x%08lX MMFAR=0x%08lX\n", cfsr, hfsr, bfar, mmfar);
     /* USER CODE END HardFault_IRQn 0 */
     while (1)
     {

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
@@ -217,6 +217,7 @@ void USBPD_DPM_UserExecute(void const* argument)
     }
 
     /* === 1秒に1回サマリ出力（重くならないように節度を守る） === */
+#if 0
     static uint32_t s_last_log = 0;
     uint32_t now               = HAL_GetTick();
 
@@ -231,6 +232,7 @@ void USBPD_DPM_UserExecute(void const* argument)
                st.rxq_capacity_frames, st.rxq_level_now, st.rxq_level_min, st.rxq_level_max, st.in_fps, st.out_fps, (long) st.dlevel_per_s, st.underrun_events, st.underrun_frames, st.overrun_events, st.overrun_frames, st.copy_us_last, st.copy_us_max);
         s_last_log = now;
     }
+#endif
     /* USER CODE END USBPD_DPM_UserExecute */
 }
 

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
@@ -223,6 +223,7 @@ void USBPD_DPM_UserExecute(void const* argument)
 
     if ((now - s_last_log) >= 1000u)
     {
+    #if 1
         AUDIO_Stats_On1sTick(); /* ← 1秒境界で確定 */
         AUDIO_Stats st;
         AUDIO_GetStats(&st);
@@ -230,6 +231,15 @@ void USBPD_DPM_UserExecute(void const* argument)
                "fps[in/out]=%u/%u, dLevel/s=%ld, "
                "UR(ev=%u,frm=%u), OR(ev=%u,frm=%u), copy_us(last=%u,max=%u)\n",
                st.rxq_capacity_frames, st.rxq_level_now, st.rxq_level_min, st.rxq_level_max, st.in_fps, st.out_fps, (long) st.dlevel_per_s, st.underrun_events, st.underrun_frames, st.overrun_events, st.overrun_frames, st.copy_us_last, st.copy_us_max);
+    #endif
+    #if 0
+        extern uint8_t s_fb_ep;
+        extern volatile uint32_t g_fb_tx_req, g_fb_tx_ok, g_fb_tx_busy, g_fb_ms_last;
+        extern volatile uint32_t g_fb_ack;
+        extern volatile uint32_t g_fb_incomp;
+        printf("[FB:rate] req=%lu ok=%lu ack=%lu incomp=%lu busy_skip=%lu ep=0x%02X\n", (unsigned long) g_fb_tx_req, (unsigned long) g_fb_tx_ok, (unsigned long) g_fb_ack, (unsigned long) g_fb_incomp, (unsigned long) g_fb_tx_busy, (unsigned) s_fb_ep);
+        g_fb_tx_req = g_fb_tx_ok = g_fb_ack = g_fb_incomp = g_fb_tx_busy = 0;
+    #endif
         s_last_log = now;
     }
 #endif

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
@@ -172,7 +172,6 @@ void USBPD_DPM_UserExecute(void const* argument)
 {
     /* USER CODE BEGIN USBPD_DPM_UserExecute */
     static uint8_t tx_safe_prev = 0;
-    static uint8_t fb_inited    = 0;
 
     if (led_toggle_counter0 == 0)
     {
@@ -220,20 +219,6 @@ void USBPD_DPM_UserExecute(void const* argument)
     /* === 1秒に1回サマリ出力（重くならないように節度を守る） === */
     static uint32_t s_last_log = 0;
     uint32_t now               = HAL_GetTick();
-
-    /* 初期化（1回だけ）：FB EP=0x81, 1ms基準=8000, bRefresh=0(毎ms送信) */
-    if (!fb_inited)
-    {
-        AUDIO_FB_Config(AUDIO_FB_EP, 8000, 3); /* ← ディスクリプタのFB EPに合わせる */
-        fb_inited = 1;
-    }
-    /* 1msごとにFBを更新（bRefreshに応じて内部で間引き） */
-    static uint32_t last_ms = 0;
-    if (now != last_ms)
-    {
-        AUDIO_FB_Task_1ms();
-        last_ms = now;
-    }
 
     if ((now - s_last_log) >= 1000u)
     {

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
@@ -183,7 +183,7 @@ void USBPD_DPM_UserExecute(void const* argument)
             HAL_GPIO_TogglePin(LED2_GPIO_Port, LED2_Pin);
 
             // printf("beep on\n");
-            AUDIO_StartBeep(1000, 500, 80);
+            // AUDIO_StartBeep(1000, 500, 80);
         }
         led_toggle_counter1 = (led_toggle_counter1 + 1) % 128;
     }
@@ -221,10 +221,10 @@ void USBPD_DPM_UserExecute(void const* argument)
     static uint32_t s_last_log = 0;
     uint32_t now               = HAL_GetTick();
 
-    /* 初期化（1回だけ）：FB EP=0x81, 1ms基準=1000, bRefresh=0(毎ms送信) */
+    /* 初期化（1回だけ）：FB EP=0x81, 1ms基準=8000, bRefresh=0(毎ms送信) */
     if (!fb_inited)
     {
-        AUDIO_FB_Config(0x81, 1000, 0); /* ← ディスクリプタのFB EPに合わせる */
+        AUDIO_FB_Config(AUDIO_FB_EP, 8000, 3); /* ← ディスクリプタのFB EPに合わせる */
         fb_inited = 1;
     }
     /* 1msごとにFBを更新（bRefreshに応じて内部で間引き） */

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
@@ -214,8 +214,8 @@ void USBPD_DPM_UserExecute(void const* argument)
         uint32_t* dst = (g_tx_safe == 1) ? &sai_tx_buf[0] : &sai_tx_buf[HALF_WORDS];
         size_t done   = AUDIO_RxQ_PopTo(dst, HALF_FRAMES); /* ← 内部でプリロール＆不足ミュート済み */
         AUDIO_AddOutFrames((uint32_t) done);
-        tx_safe_prev = g_tx_safe;
         __DMB();
+        tx_safe_prev = g_tx_safe;
     }
 #endif
     /* USER CODE END USBPD_DPM_UserExecute */

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USBPD/Target/usbpd_dpm_user.c
@@ -208,39 +208,14 @@ void USBPD_DPM_UserExecute(void const* argument)
     }
 #endif
 
+#if 1
     if (g_tx_safe != tx_safe_prev)
     {
         uint32_t* dst = (g_tx_safe == 1) ? &sai_tx_buf[0] : &sai_tx_buf[HALF_WORDS];
         size_t done   = AUDIO_RxQ_PopTo(dst, HALF_FRAMES); /* ← 内部でプリロール＆不足ミュート済み */
         AUDIO_AddOutFrames((uint32_t) done);
         tx_safe_prev = g_tx_safe;
-    }
-
-    /* === 1秒に1回サマリ出力（重くならないように節度を守る） === */
-#if 0
-    static uint32_t s_last_log = 0;
-    uint32_t now               = HAL_GetTick();
-
-    if ((now - s_last_log) >= 1000u)
-    {
-    #if 1
-        AUDIO_Stats_On1sTick(); /* ← 1秒境界で確定 */
-        AUDIO_Stats st;
-        AUDIO_GetStats(&st);
-        printf("[AUDIO] cap=%u frm, level[now/min/max]=%u/%u/%u, "
-               "fps[in/out]=%u/%u, dLevel/s=%ld, "
-               "UR(ev=%u,frm=%u), OR(ev=%u,frm=%u), copy_us(last=%u,max=%u)\n",
-               st.rxq_capacity_frames, st.rxq_level_now, st.rxq_level_min, st.rxq_level_max, st.in_fps, st.out_fps, (long) st.dlevel_per_s, st.underrun_events, st.underrun_frames, st.overrun_events, st.overrun_frames, st.copy_us_last, st.copy_us_max);
-    #endif
-    #if 0
-        extern uint8_t s_fb_ep;
-        extern volatile uint32_t g_fb_tx_req, g_fb_tx_ok, g_fb_tx_busy, g_fb_ms_last;
-        extern volatile uint32_t g_fb_ack;
-        extern volatile uint32_t g_fb_incomp;
-        printf("[FB:rate] req=%lu ok=%lu ack=%lu incomp=%lu busy_skip=%lu ep=0x%02X\n", (unsigned long) g_fb_tx_req, (unsigned long) g_fb_tx_ok, (unsigned long) g_fb_ack, (unsigned long) g_fb_incomp, (unsigned long) g_fb_tx_busy, (unsigned) s_fb_ep);
-        g_fb_tx_req = g_fb_tx_ok = g_fb_ack = g_fb_incomp = g_fb_tx_busy = 0;
-    #endif
-        s_last_log = now;
+        __DMB();
     }
 #endif
     /* USER CODE END USBPD_DPM_UserExecute */

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
@@ -233,8 +233,8 @@ void AUDIO_FB_ArmTx_if_ready(void)
 
     s_last_arm_uf = USBD_GetMicroframeHS();
 
-    // USBD_FB_ProgramNextMs(s_fb_ep);
     /* 値は直近の AUDIO_FB_Task_1ms() で準備済み（s_fb_pkt） */
+    USBD_FB_ProgramNextMs(s_fb_ep);
     if (USBD_LL_Transmit(&hUsbDeviceHS, s_fb_ep, s_fb_pkt, 3) == USBD_OK)
     {
         s_fb_busy = 1;

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
@@ -211,8 +211,8 @@ void AUDIO_FB_Task_1ms(USBD_HandleTypeDef* pdev)
     s_fb_pkt[1]           = (uint8_t) (fb_q14 >> 8);
     s_fb_pkt[2]           = (uint8_t) (fb_q14 >> 16);
 
-    /* 1ms運用では even 固定で十分（uFrame 0/4 とも even 側） */
-    USBD_FB_ForceEvenOdd(s_fb_ep, 0);
+    /* ★ “次のms”に確実に乗るよう予約してから送信 */
+    USBD_FB_ProgramNextMs(s_fb_ep);
 
     /* 実送信OKのときだけカウント＆busy=1 */
     if (USBD_LL_Transmit(&hUsbDeviceHS, s_fb_ep, s_fb_pkt, 3) == USBD_OK)

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
@@ -131,8 +131,9 @@ static uint32_t s_fb_base_q14 = 0; /* 基準値（10.14, 1ms→48<<14 / 125us→
 
 // static uint32_t s_hist47 = 0, s_hist48 = 0, s_hist49 = 0;
 
-static uint32_t g_fb_tx_req, g_fb_tx_ok, g_fb_ack, g_fb_tx_busy, g_fb_ms_last;
-volatile uint8_t s_fb_busy;    /* 既存のbusyフラグを利用 */
+static uint32_t g_fb_tx_req, g_fb_tx_ok, g_fb_tx_busy, g_fb_ms_last;
+volatile uint8_t s_fb_busy; /* 既存のbusyフラグを利用 */
+volatile uint32_t g_fb_ack;
 volatile uint32_t g_fb_incomp; /* ★ 不成立の回数を数える */
 
 static inline uint8_t FB_EP_IDX(void)
@@ -271,7 +272,7 @@ void AUDIO_FB_Task_1ms(USBD_HandleTypeDef* pdev)
                st.rxq_capacity_frames, st.rxq_level_now, st.rxq_level_min, st.rxq_level_max, st.in_fps, st.out_fps, (long) st.dlevel_per_s, st.underrun_events, st.underrun_frames, st.overrun_events, st.overrun_frames, st.copy_us_last, st.copy_us_max);
     #endif
         printf("[FB:rate] req=%lu ok=%lu ack=%lu incomp=%lu busy_skip=%lu ep=0x%02X\n", (unsigned long) g_fb_tx_req, (unsigned long) g_fb_tx_ok, (unsigned long) g_fb_ack, +(unsigned long) g_fb_incomp, (unsigned long) g_fb_tx_busy, (unsigned) s_fb_ep);
-        g_fb_tx_req = g_fb_tx_ok = g_fb_ack = g_fb_tx_busy = 0;
+        g_fb_tx_req = g_fb_tx_ok = g_fb_tx_busy = 0;
     }
 
     /* busy中は送らない（BUSY連打で間引かれるのを防ぐ） */

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
@@ -235,18 +235,6 @@ void AUDIO_FB_Task_1ms(void)
     s_fb_pkt[1] = (uint8_t) ((fb_q14 >> 8) & 0xFF);
     s_fb_pkt[2] = (uint8_t) ((fb_q14 >> 16) & 0xFF);
     //(void) USBD_LL_Transmit(&hUsbDeviceHS, s_fb_ep, s_fb_pkt, 3);
-    g_fb_tx_req++;
-    if (USBD_LL_Transmit(&hUsbDeviceHS, s_fb_ep, s_fb_pkt, 3) == USBD_OK)
-    {
-        s_fb_busy = 1; /* ★ 送出中に立てる（ACKで必ず落とす） */
-        g_fb_tx_ok++;
-    }
-    else
-    {
-        /* BUSYなど。次SOFに回す */
-        g_fb_tx_busy++;
-        return;
-    }
 
 #if 1
     static uint32_t last_ms;
@@ -276,6 +264,19 @@ void AUDIO_FB_Task_1ms(void)
         return;
     }
 #endif
+
+    g_fb_tx_req++;
+    if (USBD_LL_Transmit(&hUsbDeviceHS, s_fb_ep, s_fb_pkt, 3) == USBD_OK)
+    {
+        s_fb_busy = 1; /* ★ 送出中に立てる（ACKで必ず落とす） */
+        g_fb_tx_ok++;
+    }
+    else
+    {
+        /* BUSYなど。次SOFに回す */
+        g_fb_tx_busy++;
+        return;
+    }
 }
 
 static inline void stats_update_level(uint32_t level)

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
@@ -176,12 +176,13 @@ void AUDIO_FB_Config(uint8_t fb_ep_addr, uint32_t units_per_sec, uint8_t brefres
 /* 1msごとに“次回分の値だけ”を用意（送信はしない） */
 void AUDIO_FB_Task_1ms(void)
 {
-    static uint32_t last_ms = 0;
+#if 0
+	static uint32_t last_ms = 0;
     uint32_t now            = HAL_GetTick();
     if (now == last_ms)
         return; /* 1msに1回 */
     last_ms = now;
-
+#endif
     /* 可変に戻す前の固定48k（10.14） */
     const uint32_t fb_q14 = (48000u << 14) / 1000u; /* 0x000C0000 */
     s_fb_pkt[0]           = (uint8_t) (fb_q14);
@@ -192,13 +193,14 @@ void AUDIO_FB_Task_1ms(void)
 /* FBを“いまからの次フレーム”に備えてアーム（呼び出し元：DataIn/Incomplete/初回） */
 void AUDIO_FB_ArmTx_if_ready(void)
 {
+#if 0
     /* ★ 同じmsでは再アームしない（8kHz連打を防ぐ） */
     static uint32_t last_arm_ms = 0;
     uint32_t now                = HAL_GetTick();
     if (now == last_arm_ms)
         return;
     last_arm_ms = now;
-
+#endif
     if (!s_fb_opened || hUsbDeviceHS.dev_state != USBD_STATE_CONFIGURED)
         return;
     if (s_fb_busy)

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
@@ -99,7 +99,7 @@ static volatile uint32_t s_prev_level = 0;
 
 /* === 10.14 Feedback servo ================================================= */
 uint8_t s_fb_ep                = 0x81; /* 明示FB EP（要: ディスクリプタ一致） */
-static uint32_t s_fb_units_sec = 1000; /* 1ms基準=1000, microframe=8000 */
+static uint32_t s_fb_units_sec = 8000; /* 1ms基準=1000, microframe=8000 */
 static uint8_t s_fb_bref_pow2  = 0;    /* bRefresh=2^N (1ms基準ならN=0で毎ms) */
 static uint32_t s_fb_ticker    = 0;    /* 1ms タイムベース用 */
 
@@ -201,15 +201,6 @@ void AUDIO_FB_Task_1ms(USBD_HandleTypeDef* pdev)
     {
         s_fb_busy  = 0;
         s_fb_first = 0;
-    }
-
-    /* ★ マイクロフレーム 8回に1回だけ送る（bInterval=4 = 1ms） */
-    static uint8_t uf_mod8;
-    uf_mod8 = (uint8_t) ((uf_mod8 + 1) & 0x07);
-    if (uf_mod8 != 0)
-    {
-        /* ここでは計測用にスキップを数えない（busy_skipは busy の時だけ増やす） */
-        return;
     }
 
     USBD_EndpointTypeDef ep = pdev->ep_in[s_fb_ep & 0xF];

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
@@ -132,7 +132,8 @@ static uint32_t s_fb_base_q14 = 0; /* 基準値（10.14, 1ms→48<<14 / 125us→
 // static uint32_t s_hist47 = 0, s_hist48 = 0, s_hist49 = 0;
 
 static uint32_t g_fb_tx_req, g_fb_tx_ok, g_fb_ack, g_fb_tx_busy, g_fb_ms_last;
-volatile uint8_t s_fb_busy; /* 既存のbusyフラグを利用 */
+volatile uint8_t s_fb_busy;    /* 既存のbusyフラグを利用 */
+volatile uint32_t g_fb_incomp; /* ★ 不成立の回数を数える */
 
 static inline uint8_t FB_EP_IDX(void)
 {
@@ -270,7 +271,7 @@ void AUDIO_FB_Task_1ms(void)
                "UR(ev=%u,frm=%u), OR(ev=%u,frm=%u), copy_us(last=%u,max=%u)\n",
                st.rxq_capacity_frames, st.rxq_level_now, st.rxq_level_min, st.rxq_level_max, st.in_fps, st.out_fps, (long) st.dlevel_per_s, st.underrun_events, st.underrun_frames, st.overrun_events, st.overrun_frames, st.copy_us_last, st.copy_us_max);
     #endif
-        printf("[FB:rate] req=%lu ok=%lu ack=%lu busy_skip=%lu ep=0x%02X\n", (unsigned long) g_fb_tx_req, (unsigned long) g_fb_tx_ok, (unsigned long) g_fb_ack, (unsigned long) g_fb_tx_busy, (unsigned) s_fb_ep);
+        printf("[FB:rate] req=%lu ok=%lu ack=%lu incomp=%lu busy_skip=%lu ep=0x%02X\n", (unsigned long) g_fb_tx_req, (unsigned long) g_fb_tx_ok, (unsigned long) g_fb_ack, +(unsigned long) g_fb_incomp, (unsigned long) g_fb_tx_busy, (unsigned) s_fb_ep);
         g_fb_tx_req = g_fb_tx_ok = g_fb_ack = g_fb_tx_busy = 0;
     }
 

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.c
@@ -35,6 +35,7 @@
 
 /* USER CODE BEGIN PV */
 /* Private variables ---------------------------------------------------------*/
+extern USBD_HandleTypeDef hUsbDeviceHS;
 extern SAI_HandleTypeDef hsai_BlockA2;
 extern uint32_t sai_tx_buf[];  // main.c 側で定義済み
 extern volatile uint8_t g_tx_safe;
@@ -95,6 +96,84 @@ static volatile uint32_t s_in_fps = 0, s_out_fps = 0;
 static volatile uint32_t s_level_now  = 0;
 static volatile int32_t s_dlevel_ps   = 0;
 static volatile uint32_t s_prev_level = 0;
+
+/* === 10.14 Feedback servo ================================================= */
+static uint8_t s_fb_ep         = 0x81; /* 明示FB EP（要: ディスクリプタ一致） */
+static uint32_t s_fb_units_sec = 1000; /* 1ms基準=1000, microframe=8000 */
+static uint8_t s_fb_bref_pow2  = 0;    /* bRefresh=2^N (1ms基準ならN=0で毎ms) */
+static uint32_t s_fb_ticker    = 0;    /* 1ms タイムベース用 */
+
+/* Q14定義（10.14固定小数） */
+#define Q14 16384
+/* 目標水位（中央付近）：必要なら60%などにしても可 */
+#define RXQ_TARGET_FRAMES (RXQ_FRAMES / 2u)
+/* P/I ゲイン（保守的）：誤差1frameあたりの微調整をごく小さく */
+#define KP_NUM 1
+#define KP_DEN 2048 /* ≈ 0.00049 */
+#define KI_NUM 1
+#define KI_DEN 32768 /* ≈ 0.00003/frame·ms */
+/* 変化量の上限（ppmガード）。例: ±0.5% = ±5000ppm なら以下を調整 */
+#define FB_PPM_LIMIT 3000 /* ±3000ppm */
+
+static int32_t s_fb_i         = 0; /* I項 */
+static uint32_t s_fb_base_q14 = 0; /* 基準値（10.14, 1ms→48<<14 / 125us→6<<14 等） */
+
+static inline uint32_t clamp_u32(uint32_t v, uint32_t lo, uint32_t hi)
+{
+    return (v < lo) ? lo : (v > hi ? hi : v);
+}
+static inline int32_t clamp_s32(int32_t v, int32_t lo, int32_t hi)
+{
+    return (v < lo) ? lo : (v > hi ? hi : v);
+}
+
+void AUDIO_FB_Config(uint8_t fb_ep_addr, uint32_t units_per_sec, uint8_t brefresh_pow2)
+{
+    s_fb_ep        = fb_ep_addr;
+    s_fb_units_sec = (units_per_sec == 0) ? 1000 : units_per_sec;
+    s_fb_bref_pow2 = brefresh_pow2;
+    /* 基準（10.14）: “1単位あたりのフレーム数”<<14 */
+    /* 例：48kHz×1ms→48, 48kHz×125us→6 */
+    uint32_t base_units = USBD_AUDIO_FREQ / s_fb_units_sec;
+    s_fb_base_q14       = base_units << 14;
+    s_fb_i              = 0;
+}
+
+void AUDIO_FB_Task_1ms(void)
+{
+    extern USBD_HandleTypeDef hUsbDeviceHS;
+    if (hUsbDeviceHS.dev_state != USBD_STATE_CONFIGURED)
+        return;
+    if (!hUsbDeviceHS.ep_in[s_fb_ep & 0xF].is_used)
+        return;
+
+    /* bRefreshに合わせて送出周期を間引く（1ms基準） */
+    if ((s_fb_ticker++ & ((1u << s_fb_bref_pow2) - 1u)) != 0u)
+        return;
+
+    /* 再生未開始（プリロール中）は“基準値”のまま静かに出す */
+    const uint32_t level = s_level_now;                                   /* 直近の水位（Stats側で更新済み） */
+    int32_t e            = (int32_t) RXQ_TARGET_FRAMES - (int32_t) level; /* +:貯めたい, -:減らしたい */
+
+    /* PIサーボ（非常に弱めのゲイン） */
+    s_fb_i += e;
+    int64_t p_q14     = ((int64_t) e * KP_NUM * Q14) / (KP_DEN * (int64_t) s_fb_units_sec);
+    int64_t i_q14     = ((int64_t) s_fb_i * KI_NUM * Q14) / (KI_DEN * (int64_t) s_fb_units_sec);
+    int32_t delta_q14 = (int32_t) (p_q14 + i_q14); /* “単位あたり”の増減 in 10.14 */
+
+    /* ±ppm制限：48kHzで±3000ppm ≈ ±144frames/s → 1ms基準で ±0.144frame/ms → 10.14で約 ±2362 */
+    int32_t ppm_q14 = (int32_t) (((int64_t) USBD_AUDIO_FREQ * FB_PPM_LIMIT / 1000000) * Q14 / (int64_t) s_fb_units_sec);
+    delta_q14       = clamp_s32(delta_q14, -ppm_q14, ppm_q14);
+
+    uint32_t fb_q14 = (uint32_t) clamp_s32((int32_t) s_fb_base_q14 + delta_q14, (int32_t) (s_fb_base_q14 - ppm_q14), (int32_t) (s_fb_base_q14 + ppm_q14));
+
+    /* 10.14 を 3バイトLEで送る */
+    uint8_t fb[3];
+    fb[0] = (uint8_t) (fb_q14 & 0xFF);
+    fb[1] = (uint8_t) ((fb_q14 >> 8) & 0xFF);
+    fb[2] = (uint8_t) ((fb_q14 >> 16) & 0xFF);
+    (void) USBD_LL_Transmit(&hUsbDeviceHS, s_fb_ep, fb, 3);
+}
 
 static inline void stats_update_level(uint32_t level)
 {

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
@@ -153,6 +153,7 @@ extern "C"
     /* units_per_sec: 1ms基準なら 1000、HS 125us 基準なら 8000 */
     void AUDIO_FB_Config(uint8_t fb_ep_addr, uint32_t units_per_sec, uint8_t brefresh_pow2);
     /* 1msごとに呼ぶ（brefresh_pow2=0なら毎ms、=3なら8msごと等） */
+    uint8_t USBD_GetMicroframeHS(void);
     // void AUDIO_FB_Task_1ms(USBD_HandleTypeDef* pdev);
     void AUDIO_FB_Task_1ms(void);
     void AUDIO_FB_ArmTx_if_ready(void);

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
@@ -150,8 +150,6 @@ extern "C"
     void AUDIO_Stats_On1sTick(void);
 
     /* === フィードバックEP（10.14）サーボ ============================== */
-    /* units_per_sec: 1ms基準なら 1000、HS 125us 基準なら 8000 */
-    void AUDIO_FB_Config(uint8_t fb_ep_addr, uint32_t units_per_sec, uint8_t brefresh_pow2);
     /* 1msごとに呼ぶ（brefresh_pow2=0なら毎ms、=3なら8msごと等） */
     uint8_t USBD_GetMicroframeHS(void);
     // void AUDIO_FB_Task_1ms(USBD_HandleTypeDef* pdev);

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
@@ -153,7 +153,9 @@ extern "C"
     /* units_per_sec: 1ms基準なら 1000、HS 125us 基準なら 8000 */
     void AUDIO_FB_Config(uint8_t fb_ep_addr, uint32_t units_per_sec, uint8_t brefresh_pow2);
     /* 1msごとに呼ぶ（brefresh_pow2=0なら毎ms、=3なら8msごと等） */
-    void AUDIO_FB_Task_1ms(USBD_HandleTypeDef* pdev);
+    // void AUDIO_FB_Task_1ms(USBD_HandleTypeDef* pdev);
+    void AUDIO_FB_Task_1ms(void);
+    void AUDIO_FB_ArmTx_if_ready(void);
     /* USER CODE END EXPORTED_FUNCTIONS */
 
     /**

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
@@ -123,6 +123,31 @@ extern "C"
     /* === USB→オーディオ受信用リング（①で使用） === */
     /* リングから最大framesぶんを取り出して dst（32bit LR連続）へ書き出す。返り値=実際に取り出したフレーム数 */
     size_t AUDIO_RxQ_PopTo(uint32_t* dst_words, size_t frames);
+
+    /* === 統計: 取得・リセット ====================================== */
+    typedef struct
+    {
+        uint32_t rxq_capacity_frames; /* リング容量（frame） */
+        uint32_t rxq_level_min;       /* 観測最小水位（frame） */
+        uint32_t rxq_level_max;       /* 観測最大水位（frame） */
+        uint32_t underrun_events;     /* アンダーラン発生回数（イベント） */
+        uint32_t underrun_frames;     /* ミュート供給した累計frame数 */
+        uint32_t overrun_events;      /* オーバーラン発生回数（イベント） */
+        uint32_t overrun_frames;      /* 破棄/上書きした累計frame数 */
+        uint32_t copy_us_last;        /* 直近のPopToコピー時間[us] */
+        uint32_t copy_us_max;         /* 観測最大コピー時間[us] */
+        uint32_t rxq_level_now;       /* 現在の水位（frame） */
+        uint32_t in_fps;              /* 直近1秒の供給フレーム/秒（USB→Ring） */
+        uint32_t out_fps;             /* 直近1秒の消費フレーム/秒（Ring→SAI） */
+        int32_t dlevel_per_s;         /* 水位の傾き（+は貯まる、-は枯れる） */
+    } AUDIO_Stats;
+
+    void AUDIO_GetStats(AUDIO_Stats* out);
+    void AUDIO_ResetStats(void);
+    /* 供給/消費カウンタの加算と1秒境界処理 */
+    void AUDIO_AddInFrames(uint32_t frames);
+    void AUDIO_AddOutFrames(uint32_t frames);
+    void AUDIO_Stats_On1sTick(void);
     /* USER CODE END EXPORTED_FUNCTIONS */
 
     /**

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
@@ -153,7 +153,7 @@ extern "C"
     /* units_per_sec: 1ms基準なら 1000、HS 125us 基準なら 8000 */
     void AUDIO_FB_Config(uint8_t fb_ep_addr, uint32_t units_per_sec, uint8_t brefresh_pow2);
     /* 1msごとに呼ぶ（brefresh_pow2=0なら毎ms、=3なら8msごと等） */
-    void AUDIO_FB_Task_1ms(void);
+    void AUDIO_FB_Task_1ms(USBD_HandleTypeDef* pdev);
     /* USER CODE END EXPORTED_FUNCTIONS */
 
     /**

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
@@ -155,6 +155,7 @@ extern "C"
     /* 1msごとに呼ぶ（brefresh_pow2=0なら毎ms、=3なら8msごと等） */
     uint8_t USBD_GetMicroframeHS(void);
     // void AUDIO_FB_Task_1ms(USBD_HandleTypeDef* pdev);
+    void USBD_FB_ProgramNextMs(uint8_t ep_addr);
     void AUDIO_FB_Task_1ms(void);
     void AUDIO_FB_ArmTx_if_ready(void);
     /* USER CODE END EXPORTED_FUNCTIONS */

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_audio_if.h
@@ -148,6 +148,12 @@ extern "C"
     void AUDIO_AddInFrames(uint32_t frames);
     void AUDIO_AddOutFrames(uint32_t frames);
     void AUDIO_Stats_On1sTick(void);
+
+    /* === フィードバックEP（10.14）サーボ ============================== */
+    /* units_per_sec: 1ms基準なら 1000、HS 125us 基準なら 8000 */
+    void AUDIO_FB_Config(uint8_t fb_ep_addr, uint32_t units_per_sec, uint8_t brefresh_pow2);
+    /* 1msごとに呼ぶ（brefresh_pow2=0なら毎ms、=3なら8msごと等） */
+    void AUDIO_FB_Task_1ms(void);
     /* USER CODE END EXPORTED_FUNCTIONS */
 
     /**

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_desc.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/App/usbd_desc.c
@@ -164,7 +164,7 @@ __ALIGN_BEGIN uint8_t USBD_AUDIO_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END =
         HIBYTE(USBD_VID), /*idVendor*/
         LOBYTE(USBD_PID), /*idProduct*/
         HIBYTE(USBD_PID), /*idProduct*/
-        0x00,             /*bcdDevice rel. 2.02*/
+        0x00,             /*bcdDevice rel. 2.00*/
         0x02,
         USBD_IDX_MFC_STR,          /*Index of manufacturer  string*/
         USBD_IDX_PRODUCT_STR,      /*Index of product string*/

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
@@ -26,7 +26,7 @@
 #include "usbd_audio.h"
 
 /* USER CODE BEGIN Includes */
-
+#include "usbd_audio_if.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
@@ -438,6 +438,7 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef* pdev)
         /* USER CODE BEGIN USB_HS_FIFO_Configuration */
         HAL_PCDEx_SetRxFiFo(&hpcd_USB_OTG_HS, 0x200);
         HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG_HS, 0, 0x80);
+        HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG_HS, (AUDIO_FB_EP & 0x0F), 0x40);
         HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG_HS, (AUDIO_IN_EP & 0x0F), 0x200);
         /* USER CODE END USB_HS_FIFO_Configuration */
     }
@@ -508,11 +509,11 @@ USBD_StatusTypeDef USBD_LL_OpenEP(USBD_HandleTypeDef* pdev, uint8_t ep_addr, uin
     HAL_StatusTypeDef hal_status  = HAL_OK;
     USBD_StatusTypeDef usb_status = USBD_OK;
 
-  hal_status = HAL_PCD_EP_Open(pdev->pData, ep_addr, ep_mps, ep_type);
-  if(hal_status!=HAL_OK)
-  {
-	  __BKPT(0);
-  }
+    hal_status = HAL_PCD_EP_Open(pdev->pData, ep_addr, ep_mps, ep_type);
+    if (hal_status != HAL_OK)
+    {
+        __BKPT(0);
+    }
 
     usb_status = USBD_Get_USB_Status(hal_status);
 

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
@@ -437,7 +437,7 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef* pdev)
         HAL_PCD_RegisterIsoInIncpltCallback(&hpcd_USB_OTG_HS, PCD_ISOINIncompleteCallback);
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
         /* USER CODE BEGIN USB_HS_FIFO_Configuration */
-        HAL_PCDEx_SetRxFiFo(&hpcd_USB_OTG_HS, 0x200);
+        HAL_PCDEx_SetRxFiFo(&hpcd_USB_OTG_HS, 0x300);
         HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG_HS, 0, 0x80);
         HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG_HS, (AUDIO_FB_EP & 0x0F), 0x40);
         HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG_HS, (AUDIO_IN_EP & 0x0F), 0x200);

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
@@ -64,6 +64,16 @@ void USBD_FB_ForceEvenOdd(uint8_t ep_addr, uint8_t even)
        希望のパリティを書き戻しておく。 */
     hpcd_USB_OTG_HS.IN_ep[idx].even_odd_frame = (even ? 0U : 1U);
 }
+
+/* HS: 現在の microframe 番号(0..7)を読む */
+uint8_t USBD_GetMicroframeHS(void)
+{
+    USB_OTG_DeviceTypeDef* dev =
+        (USB_OTG_DeviceTypeDef*) ((uint32_t) USB_OTG_HS + USB_OTG_DEVICE_BASE);
+    uint32_t dsts = dev->DSTS;
+    /* FNSOF[14:8] の下位3bitが uframe(0..7) */
+    return (uint8_t) (((dsts & USB_OTG_DSTS_FNSOF_Msk) >> USB_OTG_DSTS_FNSOF_Pos) & 0x7U);
+}
 /* USER CODE END 1 */
 
 /*******************************************************************************

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
@@ -74,6 +74,23 @@ uint8_t USBD_GetMicroframeHS(void)
     /* FNSOF[14:8] の下位3bitが uframe(0..7) */
     return (uint8_t) (((dsts & USB_OTG_DSTS_FNSOF_Msk) >> USB_OTG_DSTS_FNSOF_Pos) & 0x7U);
 }
+
+/* 現在のフレーム奇偶を読み、"同じ奇偶"を指定して次のmsへ確実にスケジュール */
+static inline uint8_t USBHS_GetFrameParity(void)
+{
+    USB_OTG_DeviceTypeDef* dev =
+        (USB_OTG_DeviceTypeDef*) ((uint32_t) USB_OTG_HS + USB_OTG_DEVICE_BASE);
+    /* DSTS.FNSOF[0] が奇偶（0=even, 1=odd） */
+    return (uint8_t) ((dev->DSTS >> 8) & 0x1U);
+}
+
+void USBD_FB_ProgramNextMs(uint8_t ep_addr)
+{
+    uint8_t idx     = ep_addr & 0x0F;
+    uint8_t cur_par = USBHS_GetFrameParity(); /* 今の奇偶 */
+    /* ★ "同じ奇偶" を指定 ⇒ 次のms（8uFrame後）に乗る */
+    hpcd_USB_OTG_HS.IN_ep[idx].even_odd_frame = cur_par ? 1U : 0U;
+}
 /* USER CODE END 1 */
 
 /*******************************************************************************

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
@@ -26,7 +26,7 @@
 #include "usbd_audio.h"
 
 /* USER CODE BEGIN Includes */
-#include "usbd_audio_if.h"
+
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -184,7 +184,6 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef* hpcd, uint8_t epnum)
  * @param  hpcd: PCD handle
  * @retval None
  */
-extern volatile uint8_t s_fb_opened;
 #if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
 static void PCD_SOFCallback(PCD_HandleTypeDef* hpcd)
 #else
@@ -192,15 +191,6 @@ void HAL_PCD_SOFCallback(PCD_HandleTypeDef* hpcd)
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
 {
     /* USER CODE BEGIN HAL_PCD_SofCallback_PreTreatment */
-    /* ★ SOF直後の最初の地点でFB送信。重い処理の前に呼ぶ */
-    if (hpcd->Instance == USB_OTG_HS)
-    {
-        USBD_HandleTypeDef* pdev = (USBD_HandleTypeDef*) hpcd->pData;
-        if (s_fb_opened)
-        {
-            AUDIO_FB_Task_1ms(pdev); /* ← ここで最初に実行（最短遅延） */
-        }
-    }
 
     /* USER CODE END HAL_PCD_SofCallback_PreTreatment */
     USBD_LL_SOF((USBD_HandleTypeDef*) hpcd->pData);

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
@@ -203,6 +203,7 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef* hpcd, uint8_t epnum)
  * @param  hpcd: PCD handle
  * @retval None
  */
+extern volatile uint8_t s_fb_opened;
 #if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
 static void PCD_SOFCallback(PCD_HandleTypeDef* hpcd)
 #else
@@ -210,6 +211,15 @@ void HAL_PCD_SOFCallback(PCD_HandleTypeDef* hpcd)
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
 {
     /* USER CODE BEGIN HAL_PCD_SofCallback_PreTreatment */
+    /* ★ SOF直後の最初の地点でFB送信。重い処理の前に呼ぶ */
+    if (hpcd->Instance == USB_OTG_HS)
+    {
+        USBD_HandleTypeDef* pdev = (USBD_HandleTypeDef*) hpcd->pData;
+        if (s_fb_opened)
+        {
+            AUDIO_FB_Task_1ms(pdev); /* ← ここで最初に実行（最短遅延） */
+        }
+    }
 
     /* USER CODE END HAL_PCD_SofCallback_PreTreatment */
     USBD_LL_SOF((USBD_HandleTypeDef*) hpcd->pData);

--- a/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
+++ b/STM32CubeIDE/USB_HS_TEST/Appli/USB_DEVICE/Target/usbd_conf.c
@@ -54,6 +54,16 @@ USBD_StatusTypeDef USBD_Get_USB_Status(HAL_StatusTypeDef hal_status);
 /* Private functions ---------------------------------------------------------*/
 
 /* USER CODE BEGIN 1 */
+/* ---- FB EP の even/odd マイクロフレームを明示指定するヘルパ ---- */
+extern PCD_HandleTypeDef hpcd_USB_OTG_HS; /* HSを使用中 */
+void USBD_FB_ForceEvenOdd(uint8_t ep_addr, uint8_t even)
+{
+    uint8_t idx = ep_addr & 0x0F;
+    /* HALは even_odd_frame を見て SEVNFRM/SODDFRM を設定後、内部でトグルする。
+       bInterval=4(=8uframe)では“同じパリティを維持”したいので、送信直前に
+       希望のパリティを書き戻しておく。 */
+    hpcd_USB_OTG_HS.IN_ep[idx].even_odd_frame = (even ? 0U : 1U);
+}
 /* USER CODE END 1 */
 
 /*******************************************************************************

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Inc/usbd_audio.h
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Inc/usbd_audio.h
@@ -122,8 +122,9 @@ extern "C"
     #define AUDIO_OUT_TC 0x01U
     #define AUDIO_IN_TC  0x02U
 
-    #define AUDIO_OUT_PACKET     (uint16_t) ((USBD_AUDIO_FREQ / 1000U + 0) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
-    #define AUDIO_IN_PACKET      (uint16_t) ((USBD_AUDIO_FREQ / 1000U + 0) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
+    #define AUDIO_PKT_EXT        0U
+    #define AUDIO_OUT_PACKET     (uint16_t) ((USBD_AUDIO_FREQ / 1000U + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
+    #define AUDIO_IN_PACKET      (uint16_t) ((USBD_AUDIO_FREQ / 1000U + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
     #define AUDIO_DEFAULT_VOLUME 70U
 
     /* Number of sub-packets in the audio transfer buffer. You can modify this value but always make sure
@@ -132,9 +133,9 @@ extern "C"
     /* Total size of the audio transfer buffer */
     #define AUDIO_TOTAL_BUF_SIZE ((uint16_t) (AUDIO_OUT_PACKET * AUDIO_OUT_PACKET_NUM))
 
-    // 1msパケット（48k * 2ch * 24bit = 384B）
+    // 1msパケット（48k * 2ch * 24bit = 288B）
     #ifndef AUDIO_PACKET_SZ
-        #define AUDIO_PACKET_SZ (uint16_t) (((USBD_AUDIO_FREQ * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES) / 1000U))
+        #define AUDIO_PACKET_SZ (uint16_t) ((USBD_AUDIO_FREQ / 1000U + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
     #endif
 
     // ループバック用の小さなリング（8msぶん）

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Inc/usbd_audio.h
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Inc/usbd_audio.h
@@ -69,15 +69,20 @@ extern "C"
         #define AUDIO_OUT_EP 0x01U
     #endif /* AUDIO_OUT_EP */
 
+    #ifndef AUDIO_FB_EP
+        #define AUDIO_FB_EP 0x81U
+    #endif
+
     #ifndef AUDIO_IN_EP
-        #define AUDIO_IN_EP 0x81U
+        #define AUDIO_IN_EP 0x82U
     #endif /* AUDIO_IN_EP */
 
-    #define USB_AUDIO_CONFIG_DESC_SIZ          0xC2U
+    #define USB_AUDIO_CONFIG_DESC_SIZ          0xCBU
     #define AUDIO_INTERFACE_DESC_SIZE          0x09U
     #define USB_AUDIO_DESC_SIZ                 0x0AU
     #define AUDIO_STANDARD_ENDPOINT_DESC_SIZE  0x09U
     #define AUDIO_STREAMING_ENDPOINT_DESC_SIZE 0x07U
+    #define AUDIO_FEEDBACK_ENDPOINT_DESC_SIZE  0x09U
 
     #define AUDIO_DESCRIPTOR_TYPE         0x21U
     #define USB_DEVICE_CLASS_AUDIO        0x01U
@@ -90,6 +95,7 @@ extern "C"
     /* Audio Descriptor Types */
     #define AUDIO_INTERFACE_DESCRIPTOR_TYPE 0x24U
     #define AUDIO_ENDPOINT_DESCRIPTOR_TYPE  0x25U
+    #define AUDIO_FEEDBACK_DESC_TYPE        0x05U
 
     /* Audio Control Interface Descriptor Subtypes */
     #define AUDIO_CONTROL_HEADER          0x01U

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Inc/usbd_audio.h
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Inc/usbd_audio.h
@@ -65,6 +65,10 @@ extern "C"
         #define AUDIO_FS_BINTERVAL 0x01U
     #endif /* AUDIO_FS_BINTERVAL */
 
+    #ifndef AUDIO_FB_BINTERVAL
+        #define AUDIO_FB_BINTERVAL 0x04U
+    #endif /* AUDIO_FB_BINTERVAL */
+
     #ifndef AUDIO_OUT_EP
         #define AUDIO_OUT_EP 0x01U
     #endif /* AUDIO_OUT_EP */
@@ -122,9 +126,10 @@ extern "C"
     #define AUDIO_OUT_TC 0x01U
     #define AUDIO_IN_TC  0x02U
 
-    #define AUDIO_PKT_EXT        0U
-    #define AUDIO_OUT_PACKET     (uint16_t) ((USBD_AUDIO_FREQ / 1000U + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
-    #define AUDIO_IN_PACKET      (uint16_t) ((USBD_AUDIO_FREQ / 1000U + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
+    #define AUDIO_NUM_PER_S      1000U
+    #define AUDIO_PKT_EXT        2U
+    #define AUDIO_OUT_PACKET     (uint16_t) ((USBD_AUDIO_FREQ / AUDIO_NUM_PER_S + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
+    #define AUDIO_IN_PACKET      (uint16_t) ((USBD_AUDIO_FREQ / AUDIO_NUM_PER_S + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
     #define AUDIO_DEFAULT_VOLUME 70U
 
     /* Number of sub-packets in the audio transfer buffer. You can modify this value but always make sure
@@ -135,7 +140,7 @@ extern "C"
 
     // 1msパケット（48k * 2ch * 24bit = 288B）
     #ifndef AUDIO_PACKET_SZ
-        #define AUDIO_PACKET_SZ (uint16_t) ((USBD_AUDIO_FREQ / 1000U + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
+        #define AUDIO_PACKET_SZ (uint16_t) ((USBD_AUDIO_FREQ / AUDIO_NUM_PER_S + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
     #endif
 
     // ループバック用の小さなリング（8msぶん）

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Inc/usbd_audio.h
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Inc/usbd_audio.h
@@ -126,10 +126,15 @@ extern "C"
     #define AUDIO_OUT_TC 0x01U
     #define AUDIO_IN_TC  0x02U
 
+    #define USBD_EP_ATTR_ISOC_NOSYNC 0x00 /* attribute no synchro */
+    #define USBD_EP_ATTR_ISOC_ASYNC  0x04 /* attribute synchro by feedback  */
+    #define USBD_EP_ATTR_ISOC_ADAPT  0x08 /* attribute synchro adaptative  */
+    #define USBD_EP_ATTR_ISOC_SYNC   0x0C /* attribute synchro synchronous  */
+
     #define AUDIO_NUM_PER_S      1000U
-    #define AUDIO_PKT_EXT        2U
-    #define AUDIO_OUT_PACKET     (uint16_t) ((USBD_AUDIO_FREQ / AUDIO_NUM_PER_S + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
-    #define AUDIO_IN_PACKET      (uint16_t) ((USBD_AUDIO_FREQ / AUDIO_NUM_PER_S + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
+    #define AUDIO_PKT_EXT        999U
+    #define AUDIO_OUT_PACKET     (uint16_t) (((USBD_AUDIO_FREQ + AUDIO_PKT_EXT) / AUDIO_NUM_PER_S) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
+    #define AUDIO_IN_PACKET      (uint16_t) (((USBD_AUDIO_FREQ + AUDIO_PKT_EXT) / AUDIO_NUM_PER_S) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
     #define AUDIO_DEFAULT_VOLUME 70U
 
     /* Number of sub-packets in the audio transfer buffer. You can modify this value but always make sure
@@ -140,7 +145,7 @@ extern "C"
 
     // 1msパケット（48k * 2ch * 24bit = 288B）
     #ifndef AUDIO_PACKET_SZ
-        #define AUDIO_PACKET_SZ (uint16_t) ((USBD_AUDIO_FREQ / AUDIO_NUM_PER_S + AUDIO_PKT_EXT) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
+        #define AUDIO_PACKET_SZ (uint16_t) (((USBD_AUDIO_FREQ + AUDIO_PKT_EXT) / AUDIO_NUM_PER_S) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
     #endif
 
     // ループバック用の小さなリング（8msぶん）

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Inc/usbd_audio.h
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Inc/usbd_audio.h
@@ -122,8 +122,8 @@ extern "C"
     #define AUDIO_OUT_TC 0x01U
     #define AUDIO_IN_TC  0x02U
 
-    #define AUDIO_OUT_PACKET     (uint16_t) (((USBD_AUDIO_FREQ * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES) / 1000U))
-    #define AUDIO_IN_PACKET      (uint16_t) (((USBD_AUDIO_FREQ * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES) / 1000U))
+    #define AUDIO_OUT_PACKET     (uint16_t) ((USBD_AUDIO_FREQ / 1000U + 0) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
+    #define AUDIO_IN_PACKET      (uint16_t) ((USBD_AUDIO_FREQ / 1000U + 0) * USBD_AUDIO_CHANNELS * USBD_AUDIO_SUBFRAME_BYTES)
     #define AUDIO_DEFAULT_VOLUME 70U
 
     /* Number of sub-packets in the audio transfer buffer. You can modify this value but always make sure

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
@@ -564,6 +564,7 @@ static uint8_t USBD_AUDIO_DeInit(USBD_HandleTypeDef* pdev, uint8_t cfgidx)
  * @param  req: usb requests
  * @retval status
  */
+volatile uint8_t s_fb_opened = 0;
 static uint8_t USBD_AUDIO_Setup(USBD_HandleTypeDef* pdev, USBD_SetupReqTypedef* req)
 {
     USBD_AUDIO_HandleTypeDef* haudio;
@@ -703,7 +704,8 @@ static uint8_t USBD_AUDIO_Setup(USBD_HandleTypeDef* pdev, USBD_SetupReqTypedef* 
 
                     AUDIO_FB_Config(AUDIO_FB_EP, 1000, 0);
 
-                    s_fb_busy = 0;                             /* ★ busy解除 */
+                    s_fb_busy   = 0; /* ★ busy解除 */
+                    s_fb_opened = 1;
                     (void) USBD_LL_FlushEP(pdev, AUDIO_FB_EP); /* ★ 残データ掃除 */
                 }
                 else
@@ -715,7 +717,8 @@ static uint8_t USBD_AUDIO_Setup(USBD_HandleTypeDef* pdev, USBD_SetupReqTypedef* 
                     pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used   = 0U;
                     pdev->ep_in[AUDIOFbEpAdd & 0xF].maxpacket = 0U;
 
-                    s_fb_busy = 0; /* ★ busy解除 */
+                    s_fb_busy   = 0; /* ★ busy解除 */
+                    s_fb_opened = 0;
                 }
             }
 
@@ -879,7 +882,7 @@ static uint8_t USBD_AUDIO_SOF(USBD_HandleTypeDef* pdev)
 
     /* === ここから追加：Feedback(10.14) を毎ms送る ===
                まずは “一定48k” でホストの追従が効くことを確認する */
-    AUDIO_FB_Task_1ms(pdev);
+    // AUDIO_FB_Task_1ms(pdev);
 
     USBD_AUDIO_HandleTypeDef* haudio = (USBD_AUDIO_HandleTypeDef*) pdev->pClassDataCmsit[pdev->classId];
     if (!haudio)

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
@@ -691,7 +691,8 @@ static uint8_t USBD_AUDIO_Setup(USBD_HandleTypeDef* pdev, USBD_SetupReqTypedef* 
                         pdev->ep_in[AUDIOFbEpAdd & 0xF].bInterval = AUDIO_FS_BINTERVAL;
 
                     USBD_LL_OpenEP(pdev, AUDIOFbEpAdd, USBD_EP_TYPE_ISOC, 3);  // 3 bytes
-                    pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used = 1U;
+                    pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used   = 1U;
+                    pdev->ep_in[AUDIOFbEpAdd & 0xF].maxpacket = 3U;
 
                     printf("[FB:Open] is_used=%d, maxpacket=%d\n", pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used, pdev->ep_in[AUDIOFbEpAdd & 0xF].maxpacket);
 
@@ -703,7 +704,8 @@ static uint8_t USBD_AUDIO_Setup(USBD_HandleTypeDef* pdev, USBD_SetupReqTypedef* 
                     USBD_LL_FlushEP(pdev, AUDIOOutEpAdd);
 
                     USBD_LL_CloseEP(pdev, AUDIOFbEpAdd);
-                    pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used = 0U;
+                    pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used   = 0U;
+                    pdev->ep_in[AUDIOFbEpAdd & 0xF].maxpacket = 0U;
                 }
             }
 

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
@@ -706,6 +706,9 @@ static uint8_t USBD_AUDIO_Setup(USBD_HandleTypeDef* pdev, USBD_SetupReqTypedef* 
                     printf("[FB:Open] is_used=%d, maxpacket=%d\n", pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used, pdev->ep_in[AUDIOFbEpAdd & 0xF].maxpacket);
 
                     AUDIO_FB_Config(AUDIO_FB_EP, 1000, 0);
+
+                    s_fb_busy = 0;                             /* ★ busy解除 */
+                    (void) USBD_LL_FlushEP(pdev, AUDIO_FB_EP); /* ★ 残データ掃除 */
                 }
                 else
                 {
@@ -715,6 +718,8 @@ static uint8_t USBD_AUDIO_Setup(USBD_HandleTypeDef* pdev, USBD_SetupReqTypedef* 
                     USBD_LL_CloseEP(pdev, AUDIOFbEpAdd);
                     pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used   = 0U;
                     pdev->ep_in[AUDIOFbEpAdd & 0xF].maxpacket = 0U;
+
+                    s_fb_busy = 0; /* ★ busy解除 */
                 }
             }
 

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
@@ -63,6 +63,8 @@ EndBSPDependencies */
 #include "usbd_audio.h"
 #include "usbd_ctlreq.h"
 
+#include "usbd_audio_if.h"
+
 /** @addtogroup STM32_USB_DEVICE_LIBRARY
  * @{
  */
@@ -691,6 +693,8 @@ static uint8_t USBD_AUDIO_Setup(USBD_HandleTypeDef* pdev, USBD_SetupReqTypedef* 
                     USBD_LL_OpenEP(pdev, AUDIOFbEpAdd, USBD_EP_TYPE_ISOC, 3);  // 3 bytes
                     pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used = 1U;
 
+                    printf("[FB:Open] is_used=%d, maxpacket=%d\n", pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used, pdev->ep_in[AUDIOFbEpAdd & 0xF].maxpacket);
+
                     AUDIO_FB_Config(AUDIO_FB_EP, 1000, 0);
                 }
                 else
@@ -854,9 +858,13 @@ static uint8_t USBD_AUDIO_SOF(USBD_HandleTypeDef* pdev)
     extern USBD_HandleTypeDef hUsbDeviceHS;
     USBD_EndpointTypeDef* ep = &hUsbDeviceHS.ep_in[s_fb_ep & 0xF];
     if (hUsbDeviceHS.dev_state != USBD_STATE_CONFIGURED)
-        return (uint8_t) USBD_FAIL;
+    {
+        return (uint8_t) USBD_OK;
+    }
     if (!ep->is_used || ep->maxpacket == 0)
-        return (uint8_t) USBD_FAIL;
+    {
+        return (uint8_t) USBD_OK;
+    }
 
     // UNUSED(pdev);
     USBD_AUDIO_HandleTypeDef* haudio = (USBD_AUDIO_HandleTypeDef*) pdev->pClassDataCmsit[pdev->classId];

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
@@ -368,11 +368,11 @@ __ALIGN_BEGIN static uint8_t USBD_AUDIO_CfgDesc[USB_AUDIO_CONFIG_DESC_SIZ] __ALI
         AUDIO_FB_EP,                       /* bEndpointAddress: IN */
         0x11,                              /* bmAttributes: Isoch | Usage=Feedback */
         0x03,
-        0x00,               /* wMaxPacketSize = 3 bytes (HS:10.14) */
-        AUDIO_HS_BINTERVAL, /* bInterval: 1ms (=2^(4-1) µframes) */
-        0x00,               /* bRefresh (未使用) */
-        0x00,               /* bSynchAddress=0 */
-                            /* 09 byte(151) */
+        0x00, /* wMaxPacketSize = 3 bytes (HS:10.14) */
+        0x01, /* bInterval: 125us (=2^(1-1) µframes) */
+        0x00, /* bRefresh (未使用) */
+        0x00, /* bSynchAddress=0 */
+              /* 09 byte(151) */
 
         /* ---------------- AS(IN) Interface #2 ---------------- */
         /* Std AS Interface, alt 0 */
@@ -701,7 +701,7 @@ static uint8_t USBD_AUDIO_Setup(USBD_HandleTypeDef* pdev, USBD_SetupReqTypedef* 
 
                     printf("[FB:Open] is_used=%d, maxpacket=%d\n", pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used, pdev->ep_in[AUDIOFbEpAdd & 0xF].maxpacket);
 
-                    AUDIO_FB_Config(AUDIO_FB_EP, 1000, 0);
+                    AUDIO_FB_Config(AUDIO_FB_EP, 8000, 0);
 
                     s_fb_busy = 0;                             /* ★ busy解除 */
                     (void) USBD_LL_FlushEP(pdev, AUDIO_FB_EP); /* ★ 残データ掃除 */

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
@@ -875,17 +875,12 @@ static uint8_t USBD_AUDIO_EP0_TxReady(USBD_HandleTypeDef* pdev)
  */
 static uint8_t USBD_AUDIO_SOF(USBD_HandleTypeDef* pdev)
 {
-    USBD_EndpointTypeDef ep = pdev->ep_in[s_fb_ep & 0xF];
-    if (pdev->dev_state != USBD_STATE_CONFIGURED)
-    {
-        return (uint8_t) USBD_OK;
-    }
-    if (!ep.is_used || ep.maxpacket == 0)
-    {
-        return (uint8_t) USBD_OK;
-    }
-
     // UNUSED(pdev);
+
+    /* === ここから追加：Feedback(10.14) を毎ms送る ===
+               まずは “一定48k” でホストの追従が効くことを確認する */
+    AUDIO_FB_Task_1ms(pdev);
+
     USBD_AUDIO_HandleTypeDef* haudio = (USBD_AUDIO_HandleTypeDef*) pdev->pClassDataCmsit[pdev->classId];
     if (!haudio)
     {
@@ -903,10 +898,6 @@ static uint8_t USBD_AUDIO_SOF(USBD_HandleTypeDef* pdev)
 
         printf("first transmit.\n");
     }
-
-    /* === ここから追加：Feedback(10.14) を毎ms送る ===
-           まずは “一定48k” でホストの追従が効くことを確認する */
-    AUDIO_FB_Task_1ms(pdev);
 
     return (uint8_t) USBD_OK;
 }

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
@@ -368,11 +368,11 @@ __ALIGN_BEGIN static uint8_t USBD_AUDIO_CfgDesc[USB_AUDIO_CONFIG_DESC_SIZ] __ALI
         AUDIO_FB_EP,                       /* bEndpointAddress: IN */
         0x11,                              /* bmAttributes: Isoch | Usage=Feedback */
         0x03,
-        0x00, /* wMaxPacketSize = 3 bytes (HS:10.14) */
-        0x01, /* bInterval: 125us (=2^(1-1) µframes) */
-        0x00, /* bRefresh (未使用) */
-        0x00, /* bSynchAddress=0 */
-              /* 09 byte(151) */
+        0x00,               /* wMaxPacketSize = 3 bytes (HS:10.14) */
+        AUDIO_HS_BINTERVAL, /* bInterval: 1ms (=2^(4-1) µframes) */
+        0x00,               /* bRefresh (未使用) */
+        0x00,               /* bSynchAddress=0 */
+                            /* 09 byte(151) */
 
         /* ---------------- AS(IN) Interface #2 ---------------- */
         /* Std AS Interface, alt 0 */
@@ -701,7 +701,7 @@ static uint8_t USBD_AUDIO_Setup(USBD_HandleTypeDef* pdev, USBD_SetupReqTypedef* 
 
                     printf("[FB:Open] is_used=%d, maxpacket=%d\n", pdev->ep_in[AUDIOFbEpAdd & 0xF].is_used, pdev->ep_in[AUDIOFbEpAdd & 0xF].maxpacket);
 
-                    AUDIO_FB_Config(AUDIO_FB_EP, 8000, 0);
+                    AUDIO_FB_Config(AUDIO_FB_EP, 1000, 0);
 
                     s_fb_busy = 0;                             /* ★ busy解除 */
                     (void) USBD_LL_FlushEP(pdev, AUDIO_FB_EP); /* ★ 残データ掃除 */

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
@@ -880,13 +880,12 @@ static uint8_t USBD_AUDIO_EP0_TxReady(USBD_HandleTypeDef* pdev)
  */
 static uint8_t USBD_AUDIO_SOF(USBD_HandleTypeDef* pdev)
 {
-    extern USBD_HandleTypeDef hUsbDeviceHS;
-    USBD_EndpointTypeDef* ep = &hUsbDeviceHS.ep_in[s_fb_ep & 0xF];
-    if (hUsbDeviceHS.dev_state != USBD_STATE_CONFIGURED)
+    USBD_EndpointTypeDef ep = pdev->ep_in[s_fb_ep & 0xF];
+    if (pdev->dev_state != USBD_STATE_CONFIGURED)
     {
         return (uint8_t) USBD_OK;
     }
-    if (!ep->is_used || ep->maxpacket == 0)
+    if (!ep.is_used || ep.maxpacket == 0)
     {
         return (uint8_t) USBD_OK;
     }
@@ -912,7 +911,7 @@ static uint8_t USBD_AUDIO_SOF(USBD_HandleTypeDef* pdev)
 
     /* === ここから追加：Feedback(10.14) を毎ms送る ===
            まずは “一定48k” でホストの追従が効くことを確認する */
-    AUDIO_FB_Task_1ms();
+    AUDIO_FB_Task_1ms(pdev);
 
     return (uint8_t) USBD_OK;
 }
@@ -1004,12 +1003,12 @@ static uint8_t USBD_AUDIO_IsoINIncomplete(USBD_HandleTypeDef* pdev, uint8_t epnu
         // printf("incomplete...\n");
     }
 
-    if ((epnum & 0x0F) == FB_EP_IDX_)
+    if ((epnum & 0x0F) == (AUDIOFbEpAdd & 0x0F))
     {
         s_fb_busy = 0; /* ★ 完了しなくても次回送れるように busy を解放 */
         g_fb_incomp++;
         /* 必要なら一度だけフラッシュ（頻発させないこと） */
-        /* USBD_LL_FlushEP(pdev, AUDIO_FB_EP); */
+        /* USBD_LL_FlushEP(pdev, AUDIOFbEpAdd); */
     }
 
     return (uint8_t) USBD_OK;

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
@@ -135,6 +135,15 @@ extern int8_t AUDIO_Mic_GetPacket(uint8_t* dst, uint16_t len);
 
 extern uint8_t s_fb_ep;
 
+/* FB送信 ACK カウンタ（if側から参照） */
+volatile uint32_t g_fb_ack;
+extern uint8_t s_fb_busy; /* if側のフラグを参照 */
+#ifdef AUDIO_FB_EP
+    #define FB_EP_IDX_ (AUDIO_FB_EP & 0x0F)
+#else
+    #define FB_EP_IDX_ (s_fb_ep & 0x0F)
+#endif
+
 __attribute__((aligned(4))) static uint8_t s_fb_pkt[4];  // 3バイト送るが4バイト確保してアライン確保
 
 static uint8_t mic_packet[AUDIO_IN_PACKET];
@@ -800,6 +809,14 @@ static uint8_t USBD_AUDIO_DataIn(USBD_HandleTypeDef* pdev, uint8_t epnum)
         (void) USBD_LL_Transmit(pdev, AUDIOInEpAdd, mic_packet, AUDIO_IN_PACKET);
 
         // printf("data in!\n");
+    }
+
+    /* epnum は EP番号(0..15)。アドレスではない点に注意 */
+    if ((epnum & 0x0F) == FB_EP_IDX_)
+    {
+        s_fb_busy = 0; /* ★ 完了で busy を確実に落とす */
+        g_fb_ack++;    /* ★ ACK をカウント */
+        return (uint8_t) USBD_OK;
     }
 
     /* Only OUT data are processed */

--- a/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
+++ b/STM32CubeIDE/USB_HS_TEST/Middlewares/ST/STM32_USB_Device_Library/Class/AUDIO/Src/usbd_audio.c
@@ -136,16 +136,11 @@ extern int8_t AUDIO_Mic_GetPacket(uint8_t* dst, uint16_t len);
 extern uint8_t s_fb_ep;
 
 /* FB送信 ACK カウンタ（if側から参照） */
-volatile uint32_t g_fb_ack;
 extern uint8_t s_fb_busy; /* if側のフラグを参照 */
+extern uint32_t g_fb_ack;
 extern uint32_t g_fb_incomp;
-#ifdef AUDIO_FB_EP
-    #define FB_EP_IDX_ (AUDIO_FB_EP & 0x0F)
-#else
-    #define FB_EP_IDX_ (s_fb_ep & 0x0F)
-#endif
 
-__attribute__((aligned(4))) static uint8_t s_fb_pkt[4];  // 3バイト送るが4バイト確保してアライン確保
+__attribute__((section(".dma_nocache"), aligned(4))) static uint8_t s_fb_pkt[4];  // 3バイト送るが4バイト確保してアライン確保
 
 static uint8_t mic_packet[AUDIO_IN_PACKET];
 /**
@@ -818,7 +813,7 @@ static uint8_t USBD_AUDIO_DataIn(USBD_HandleTypeDef* pdev, uint8_t epnum)
     }
 
     /* epnum は EP番号(0..15)。アドレスではない点に注意 */
-    if ((epnum & 0x0F) == FB_EP_IDX_)
+    if ((epnum & 0x0F) == (AUDIOFbEpAdd & 0x0F))
     {
         s_fb_busy = 0; /* ★ 完了で busy を確実に落とす */
         g_fb_ack++;    /* ★ ACK をカウント */


### PR DESCRIPTION
## 目的
UAC1/HSでFB EP導入し、時間軸ノイズとアンダーランを抑制

## 変更点（要点）
- usbd_audio.c: SOFガード/FB送出ロジック調整
- usbd_audio_if.c: ハーフバッファ=48*n、32bit左詰の整理
- usbd_conf.c: FB用Tx FIFO割当
- リンカ/MPU: SAIバッファ非キャッシュ化

## 動作条件
- Sample rates: 48kHz
- Format: 24bit
- ハーフバッファフレーム数: 48の倍数

## 再現手順
1) Windowsでデバイスを48kHzに設定
2) Spotify/テストトーン再生